### PR TITLE
[css] position fixed on full size modals

### DIFF
--- a/lib/style/modals.styl
+++ b/lib/style/modals.styl
@@ -60,6 +60,7 @@
 @media screen and (max-width: 600px)
 
   .modal
+    position: fixed
     height: 100%
     width: 100%
     top: 0

--- a/public/css/demo.css
+++ b/public/css/demo.css
@@ -1782,6 +1782,7 @@ nav ul a {
 }
 @media screen and (max-width: 600px) {
   .modal {
+    position: fixed;
     height: 100%;
     width: 100%;
     top: 0;


### PR DESCRIPTION
Prevents modal appearing cut off at the top of the page if the page is scrolled down when modal opens.
