### PR TITLE
[docs] fixing bullet character encoding in css

### DIFF
--- a/public/styl/main.styl
+++ b/public/styl/main.styl
@@ -39,7 +39,7 @@ footer[role='contentinfo']
 
   li:not(:last-of-type)
     &:after
-      content: '•'
+      content: '\2219'
       margin: 0 5px 0 10px
 
   p


### PR DESCRIPTION
Fixes bullet character encoding in on the doc's footer:
![screen shot 2015-03-30 at 1 27 51 pm](https://cloud.githubusercontent.com/assets/297045/6905996/9b79f6a6-d6e0-11e4-9ed0-36db35f303da.png)
