### PR TITLE
[fix] jade syntax on colors template

### DIFF
--- a/public/templates/colors.jade
+++ b/public/templates/colors.jade
@@ -5,69 +5,69 @@ section
   h3 Blues
   ul.cf.list-unstyled.list-inline
     li.color.blue1
-      $blue-saturated-darker
+      | $blue-saturated-darker
     li.color.blue2
-      $blue-saturated-dark
+      | $blue-saturated-dark
     li.color.blue3
-      $blue-saturated
+      | $blue-saturated
     li.color.blue4
-      $blue-saturated-light
+      | $blue-saturated-light
     li.color.blue5
-      $blue-saturated-lighter
+      | $blue-saturated-lighter
 
   ul.cf.list-unstyled.list-inline
     li.color.blue6
-      $blue
+      | $blue
     li.color.blue7
-      $blue-light
+      | $blue-light
     li.color.blue8
-      $blue-lighter
+      | $blue-lighter
 
   h3 Monochromatic
   ul.cf.list-unstyled.list-inline
     li.color.gray1
-      $gray-darker
+      | $gray-darker
     li.color.gray2
-      $gray-dark
+      | $gray-dark
     li.color.gray3
-      $gray
+      | $gray
     li.color.gray4
       span $gray-light
     li.color.gray5
-      $gray-lighter
+      | $gray-lighter
 
   h3 Pinks
   ul.cf.list-unstyled.list-inline
     li.color.pink1
-      $pink
+      | $pink
     li.color.pink2
-      $pink-light
+      | $pink-light
     li.color.pink3
-      $pink-lighter
+      | $pink-lighter
 
   h3 Reds
   ul.cf.list-unstyled.list-inline
     li.color.red1
-      $red
+      | $red
     li.color.red2
-      $red-light
+      | $red-light
     li.color.red3
-      $red-lighter
+      | $red-lighter
 
   h3 Oranges
   ul.cf.list-unstyled.list-inline
     li.color.orange1
-      $orange
+      | $orange
     li.color.orange2
-      $orange-light
+      | $orange-light
     li.color.orange3
-      $orange-lighter
+      | $orange-lighter
 
   h3 Greens
   ul.cf.list-unstyled.list-inline
     li.color.green1
-      $green
+      | $green
     li.color.green2
-      $green-light
+      | $green-light
     li.color.green3
-      $green-lighter
+      | $green-lighter


### PR DESCRIPTION
Fixes this error:
<img width="749" alt="screen shot 2017-06-21 at 10 24 29 am" src="https://user-images.githubusercontent.com/4055156/27397651-eacdf7c2-566b-11e7-8779-84d5b94fadb4.png">
